### PR TITLE
add CheckLock() which returns an error instead of calling log.Fatal; …

### DIFF
--- a/single.go
+++ b/single.go
@@ -4,13 +4,14 @@ package single
 
 import (
 	"errors"
+	"log"
 	"os"
 )
 
 var (
-	// ErrAlreadyRunning
+	// ErrAlreadyRunning -- the instance is already running
 	ErrAlreadyRunning = errors.New("the program is already running")
-	//
+	// Lockfile -- the lock file to check
 	Lockfile string
 )
 
@@ -23,4 +24,11 @@ type Single struct {
 // New creates a Single instance
 func New(name string) *Single {
 	return &Single{name: name}
+}
+
+// Lock tries to obtain an exclude lock on a lockfile and exits the program if an error occurs
+func (s *Single) Lock() {
+	if err := s.CheckLock(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/single_unix.go
+++ b/single_unix.go
@@ -8,12 +8,13 @@ import (
 	"syscall"
 )
 
-// Lock tries to obtain an exclude lock on a lockfile and exits the program if an error occurs
-func (s *Single) Lock() {
+// CheckLock tries to obtain an exclude lock on a lockfile and returns an error if one occurs
+func (s *Single) CheckLock() error {
+
 	// open/create lock file
 	f, err := os.OpenFile(s.Filename(), os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	s.file = f
 	// set the lock type to F_WRLCK, therefor the file has to be opened writable
@@ -23,8 +24,10 @@ func (s *Single) Lock() {
 	}
 	// try to obtain an exclusive lock - FcntlFlock seems to be the portable *ix way
 	if err := syscall.FcntlFlock(s.file.Fd(), syscall.F_SETLK, &flock); err != nil {
-		log.Fatal(ErrAlreadyRunning)
+		return ErrAlreadyRunning
 	}
+
+	return nil
 }
 
 // Unlock releases the lock, closes and removes the lockfile. All errors will be reported directly.

--- a/single_windows.go
+++ b/single_windows.go
@@ -17,20 +17,20 @@ func (s *Single) Filename() string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("%s.lock", s.name))
 }
 
-// Lock tries to remove the lock file, if it exists.
-// If the file is already open by another instance of the program,
-// remove will fail and exit the program.
-func (s *Single) Lock() {
+// CheckLock tries to obtain an exclude lock on a lockfile and returns an error if one occurs
+func (s *Single) CheckLock() error {
 
 	if err := os.Remove(s.Filename()); err != nil && !os.IsNotExist(err) {
-		log.Fatal(ErrAlreadyRunning)
+		return ErrAlreadyRunning
 	}
 
 	file, err := os.OpenFile(s.Filename(), os.O_EXCL|os.O_CREATE, 0600)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	s.file = file
+
+	return nil
 }
 
 // Unlock closes and removes the lockfile.


### PR DESCRIPTION
…make Lock() call log.Fatal on CheckLock() error (default behavior)