### PR TITLE
README: Update demo code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@
     )
 
     func main() {
-        s := single.New("name")
-        s.Lock()
-        defer s.Unlock()
+        s := single.New("your-app-name")
+        if err := s.CheckLock(); err != nil && err == single.ErrAlreadyRunning {
+            log.Fatal("another instance of the app is already running, exiting")
+        } else if err != nil {
+            // Another error occurred, might be worth handling it as well
+            log.Fatalf("failed to acquire exclusive app lock: %v", err)
+        }
+        defer s.TryUnlock()
+
         log.Println("working")
         time.Sleep(60 * time.Second)
         log.Println("finished")


### PR DESCRIPTION
Instead of using the old functions 'Lock()' and 'Unlock()' which
log errors directly, use 'CheckLog()' and 'TryUnlock()' which
return errors instead.