### PR TITLE
use os.TempDir() instead of '/var/lock' to prevent permission denied …

### DIFF
--- a/single_linux.go
+++ b/single_linux.go
@@ -10,5 +10,5 @@ func (s *Single) Filename() string {
 	if len(Lockfile) > 0 {
 		return Lockfile
 	}
-	return filepath.Join("/var/lock", fmt.Sprintf("%s.lock", s.name))
+	return filepath.Join(os.TempDir(), fmt.Sprintf("%s.lock", s.name))
 }


### PR DESCRIPTION
I encountered an error on ArchLinux whereby I couldn't write to '/var/lock' as a normal user. I switched to using os.TempDir() and it worked. Hope this helps someone else who might encounter a similar issue.